### PR TITLE
Add Docker example using rAdvisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:20.04
+
+# Install make & gcc
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y make gcc
+
+# Copy and build milli-stress
+COPY . /opt/milli-stress
+WORKDIR /opt/milli-stress
+RUN make
+
+# The entrypoint command allows the container to be used
+# as if it was the normal executable,
+# passing through all arguments
+ENTRYPOINT ["./milli-stress"]


### PR DESCRIPTION
The example in the README has been tested using the same CloudLab profile used in the rest of the README, `Infosphere/C8220-Ubuntu18.04LTS64bit` (re-using the instructions up until installing Collectl).